### PR TITLE
Modify Circle CI config so that the CI runs RSpec and Rubocop separately

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,14 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Run the default task
+          name: Run RSpec
+          command: |
+            gem install bundler -v 2.3.7
+            bundle install
+            bundle exec rake
+      - run:
+          name: Run Rubocop
           command: |
             gem install bundler -v 2.3.7
             bundle install
             bundle exec rubocop
-            bundle exec rake

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,15 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Run RSpec
+          name: bundle install
           command: |
             gem install bundler -v 2.3.7
             bundle install
+      - run:
+          name: Run RSpec
+          command: |
             bundle exec rake
       - run:
           name: Run Rubocop
           command: |
-            gem install bundler -v 2.3.7
-            bundle install
             bundle exec rubocop


### PR DESCRIPTION
Modified `.circleci/config.yml` to make the result of the build on Circle CI be easy to view