### PR TITLE
Run only RSpec in the 'RSpec' step of the build on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run:
           name: Run RSpec
           command: |
-            bundle exec rake
+            bundle exec rspec
       - run:
           name: Run Rubocop
           command: |


### PR DESCRIPTION
Not to run Rubocop in the 'RSpec' step on CI